### PR TITLE
fix: 複数日シフト一括登録機能を実装

### DIFF
--- a/frontend/src/components/ShiftDialog.tsx
+++ b/frontend/src/components/ShiftDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
@@ -29,6 +29,7 @@ interface ShiftDialogProps {
     >
   ) => void;
   useDateTime?: boolean;
+  selectedDates?: Date[];
 }
 
 const ShiftDialog: React.FC<ShiftDialogProps> = ({
@@ -37,13 +38,13 @@ const ShiftDialog: React.FC<ShiftDialogProps> = ({
   contentText,
   mode,
   formData = {},
-  shiftId,
   onClose,
   onSubmit,
   onApprove,
   onReject,
   onChange,
   useDateTime = false,
+  selectedDates,
 }) => {
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
@@ -54,7 +55,9 @@ const ShiftDialog: React.FC<ShiftDialogProps> = ({
         {mode === "register" && onChange && (
           <form id="shift-form" className="shift-form">
             <div className="form-group">
-              <label htmlFor="start_time">開始時間</label>
+              <label htmlFor="start_time">
+                {selectedDates && selectedDates.length > 1 ? "開始時間（各日共通）" : "開始時間"}
+              </label>
               <input
                 type={useDateTime ? "datetime-local" : "time"}
                 id="start_time"
@@ -66,7 +69,14 @@ const ShiftDialog: React.FC<ShiftDialogProps> = ({
             </div>
 
             <div className="form-group">
-              <label htmlFor="end_time">終了時間</label>
+              <label htmlFor="end_time">
+                {selectedDates && selectedDates.length > 1 ? "終了時間（各日共通）" : "終了時間"}
+                {selectedDates && selectedDates.length > 1 && (
+                  <small style={{ display: "block", marginTop: "4px", color: "#666" }}>
+                    ※ 日をまたぐ場合は翌日の時間として登録されます
+                  </small>
+                )}
+              </label>
               <input
                 type={useDateTime ? "datetime-local" : "time"}
                 id="end_time"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -134,6 +134,10 @@ export const shiftAPI = {
     return api.post("/api/shifts", data);
   },
 
+  bulkRegisterShifts: async (data: any) => {
+    return api.post("/api/shifts/bulk", data);
+  },
+
   updateShift: async (id: number, data: any) => {
     return api.put(`/api/shifts/${id}`, data);
   },


### PR DESCRIPTION
## Summary
- カレンダーで複数日をドラッグ選択した際に、同一時間帯でシフトを一括登録できる機能を追加
- 複数日選択時のUIを改善し、時間のみ入力するように変更
- 日付範囲選択のバグを修正

## Changes
- `ShiftManagementPage.tsx`: 複数日選択ロジックと一括登録処理を実装
- `ShiftDialog.tsx`: 複数日選択モード対応のUI改善
- `api.ts`: bulk APIエンドポイントのクライアント側実装

## Test plan
- [x] カレンダーで複数日をドラッグ選択
- [x] 時間のみ入力できることを確認
- [x] 選択した全日程に同じ時間でシフトが登録されることを確認
- [x] 日をまたぐシフト（22:00-02:00など）が正しく登録されることを確認
- [x] 日付範囲の境界が正しく処理されることを確認（最終日の翌日が含まれない）

🤖 Generated with [Claude Code](https://claude.ai/code)